### PR TITLE
fix: specify jina version number in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-jina
+jina>=1.0
 jupyter


### PR DESCRIPTION
This should fix the binder issue described in [#2022](https://github.com/jina-ai/jina/issues/2022)